### PR TITLE
Implement EIP-712 Message Hashing

### DIFF
--- a/contracts/SolverTrampoline.sol
+++ b/contracts/SolverTrampoline.sol
@@ -3,5 +3,34 @@ pragma solidity ^0.8.17;
 
 import { Authentication, Settlement } from "./CoWProtocol.sol";
 
+/// @title CoW Protocol Solver Trampoline
+/// @author CoW Protocol Developers
+/// @dev A solver trampoline contract that allows permissionless execution of
+/// signed authorized settlements. This can be used to allow relayers to execute
+/// settlements on behalf solvers without being a registered solver themselves.
 contract SolverTrampoline {
+    /// @dev The domain separator for signing EIP-712 settlements.
+    bytes32 public immutable domainSeparator;
+
+    constructor() {
+        domainSeparator = keccak256(abi.encode(
+            keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"),
+            block.chainid,
+            address(this)
+        ));
+    }
+
+    /// @dev Returns the EIP-712 signing digest for the specified settlement
+    /// hash and nonce.
+    function settlementMessage(bytes calldata settlement, uint256 nonce) public view returns (bytes32) {
+        return keccak256(abi.encodePacked(
+            hex"1901",
+            domainSeparator,
+            keccak256(abi.encode(
+                keccak256("Settlement(bytes settlement,uint256 nonce)"),
+                keccak256(settlement),
+                nonce
+            ))
+        ));
+    }
 }

--- a/test/SolverTrampoline.ts
+++ b/test/SolverTrampoline.ts
@@ -7,14 +7,51 @@ describe("SolverTrampoline", function () {
     const SolverTrampoline = await ethers.getContractFactory("SolverTrampoline");
     const solverTrampoline = await SolverTrampoline.deploy();
 
-    return { solverTrampoline };
+    const { chainId } = await ethers.provider.getNetwork();
+    const domain = {
+      chainId,
+      verifyingContract: solverTrampoline.address,
+    };
+
+    return { solverTrampoline, domain };
   }
 
   describe("Deployment", function () {
     it("Should have an address", async function () {
       const { solverTrampoline } = await loadFixture(fixture);
 
-      expect(solverTrampoline.address).to.not.equal(ethers.constants.AddressZero);
+      expect(solverTrampoline.address)
+        .to.not.equal(ethers.constants.AddressZero);
+    });
+  });
+
+  describe("settlementMessage", function () {
+    it("Should have a well defined domain separator", async function () {
+      const { solverTrampoline, domain } = await loadFixture(fixture);
+
+      expect(await solverTrampoline.domainSeparator())
+        .to.equal(ethers.utils._TypedDataEncoder.hashDomain(domain));
+    });
+
+    it("Should compute a EIP-712 message for signing", async function () {
+      const { solverTrampoline, domain } = await loadFixture(fixture);
+      const settlement = "0x01020304";
+      const nonce = 42;
+
+      expect(await solverTrampoline.settlementMessage(settlement, nonce))
+        .to.equal(
+          ethers.utils._TypedDataEncoder.hash(domain, EIP712_TYPES, {
+            settlement,
+            nonce,
+          }),
+        );
     });
   });
 });
+
+const EIP712_TYPES = {
+  Settlement: [
+    { name: "settlement", type: "bytes" },
+    { name: "nonce", type: "uint256" },
+  ],
+};


### PR DESCRIPTION
This PR implements EIP-712 messaging hashing for the signed settlement data.

Currently, the idea is that trampolined settlements sign two things:
- The settlement calldata: this is for obvious reasons, to disallow tampering of the solver's calldata by the caller.
- The solver's nonce: this will be used (in a future PR) to protect against solver transaction replaying. This is important, for example, with "withdraw" settlements, as there are no orders that would "implicitely" allow for replay protection.

### Test Plan

Added some unit tests.