### PR TITLE
Initialize CoW Protocol Contracts

### DIFF
--- a/contracts/SolverTrampoline.sol
+++ b/contracts/SolverTrampoline.sol
@@ -9,10 +9,18 @@ import { Authentication, Settlement } from "./CoWProtocol.sol";
 /// signed authorized settlements. This can be used to allow relayers to execute
 /// settlements on behalf solvers without being a registered solver themselves.
 contract SolverTrampoline {
+    /// @dev The CoW Protocol settlement contract.
+    Settlement public immutable settlementContract;
+    /// @dev the CoW Protocol solver authenticator.
+    Authentication public immutable solverAuthenticator;
+
     /// @dev The domain separator for signing EIP-712 settlements.
     bytes32 public immutable domainSeparator;
 
-    constructor() {
+    constructor(Settlement settlementContract_) {
+        settlementContract = settlementContract_;
+        solverAuthenticator = settlementContract_.authenticator();
+        
         domainSeparator = keccak256(abi.encode(
             keccak256("EIP712Domain(uint256 chainId,address verifyingContract)"),
             block.chainid,

--- a/contracts/test/CoWProtocol.sol
+++ b/contracts/test/CoWProtocol.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+pragma solidity ^0.8.17;
+
+import { Authentication, Settlement } from "../CoWProtocol.sol";
+
+contract TestAuthentication is Authentication {
+    address public allowedSolver;
+
+    constructor(address allowedSolver_) {
+        allowedSolver = allowedSolver_;
+    }
+
+    function isSolver(address solver) external view returns (bool) {
+        return solver == allowedSolver;
+    }
+}
+
+contract TestSettlement is Settlement {
+    Authentication public authenticator;
+
+    constructor(address allowedSolver) {
+        authenticator = new TestAuthentication(allowedSolver);
+    }
+}

--- a/test/SolverTrampoline.ts
+++ b/test/SolverTrampoline.ts
@@ -4,8 +4,21 @@ import { ethers } from "hardhat";
 
 describe("SolverTrampoline", function () {
   async function fixture() {
+    const [deployer, solver, notSolver] = await ethers.getSigners();
+
+    const TestSettlement = await ethers.getContractFactory("TestSettlement");
+    const settlementContract = await TestSettlement
+      .connect(deployer)
+      .deploy(solver.address);
+    const TestAuthentication = await ethers.getContractFactory("TestAuthentication");
+    const solverAuthenticator = TestAuthentication
+      .connect(deployer)
+      .attach(await settlementContract.authenticator());
+
     const SolverTrampoline = await ethers.getContractFactory("SolverTrampoline");
-    const solverTrampoline = await SolverTrampoline.deploy();
+    const solverTrampoline = await SolverTrampoline
+      .connect(deployer)
+      .deploy(settlementContract.address);
 
     const { chainId } = await ethers.provider.getNetwork();
     const domain = {
@@ -13,7 +26,14 @@ describe("SolverTrampoline", function () {
       verifyingContract: solverTrampoline.address,
     };
 
-    return { solverTrampoline, domain };
+    return {
+      solver,
+      notSolver,
+      settlementContract,
+      solverAuthenticator,
+      solverTrampoline,
+      domain,
+    };
   }
 
   describe("Deployment", function () {
@@ -22,6 +42,16 @@ describe("SolverTrampoline", function () {
 
       expect(solverTrampoline.address)
         .to.not.equal(ethers.constants.AddressZero);
+    });
+
+    it("Should set CoW Protocol contract addresses", async function () {
+      const { settlementContract, solverAuthenticator, solverTrampoline } =
+        await loadFixture(fixture);
+
+      expect(await solverTrampoline.settlementContract())
+        .to.equal(settlementContract.address);
+      expect(await solverTrampoline.solverAuthenticator())
+        .to.equal(solverAuthenticator.address);
     });
   });
 


### PR DESCRIPTION
This PR initializes relavent CoW Protocol contract addresses in the solver trampoline. These contracts are needed as part of trampolining for:
- `settlementContract`: to execute the trampolined settlement
- `solverAuthenticator`: to authenticate the signer of the trampolined settlement

### Test Plan

Introduced some `Test*` CoW Protocol contracts and added some unit tests for the trampoline contract.