### PR TITLE
Optimize Settlement Call

### DIFF
--- a/contracts/SolverTrampoline.sol
+++ b/contracts/SolverTrampoline.sol
@@ -42,8 +42,44 @@ contract SolverTrampoline {
 
     /// @dev Executes a settlement on behalf of a solver.
     function settle(bytes calldata settlement, uint256 nonce, bytes32 r, bytes32 s, uint8 v) external {
-        bytes32 messageDigest = settlementMessage(settlement, nonce);
+        address settlementAddress = address(settlementContract);
+        bytes32 settlementDigest;
+        assembly {
+            // Load the "free memory pointer" as the starting offset, in memory,
+            // to copy the settlement calldata to.
+            // See <https://docs.soliditylang.org/en/v0.8.17/internals/layout_in_memory.html>.
+            let settlementBuffer := mload(0x40)
+            calldatacopy(settlementBuffer, settlement.offset, settlement.length)
+
+            // Compute the settlement digest, we use this later when verifying
+            // the signer of the settlement calldata.
+            settlementDigest := keccak256(settlementBuffer, settlement.length)
+
+            // Optimistically call the settlement contract. We use assembly for
+            // this for two reasons:
+            // 1. It avoids a `EXTCODESIZE` instruction, since the settlement
+            //    contract existing is a valid assumption here (we already
+            //    called it in the constructor)
+            // 2. It avoids inefficient code generation around copying memory
+            //    for low-level `.call()`s.
+            if iszero(call(
+                gas(),
+                settlementAddress,
+                0, // value
+                settlementBuffer,
+                settlement.length,
+                0, // outOffset
+                0  // outSize
+            )) {
+                // Propagate the revert error.
+                returndatacopy(0, 0, returndatasize())
+                revert(0, returndatasize())
+            }
+        }
+
+        bytes32 messageDigest = settlementMessage(settlementDigest, nonce);
         address solver = ecrecover(messageDigest, v, r, s);
+
         if (solver == address(0) || !solverAuthenticator.isSolver(solver)) {
             revert Unauthorized();
         }
@@ -52,26 +88,25 @@ contract SolverTrampoline {
         }
 
         nonces[solver] = nonce + 1;
-        (bool success, bytes memory data) = address(settlementContract).call(settlement);
-        if (!success) {
-            // Propagate the revert error.
-            assembly {
-                revert(add(data, 32), mload(data))
-            }
-        }
 
         emit TrampolinedSettlement(solver, nonce);
     }
 
     /// @dev Returns the EIP-712 signing digest for the specified settlement
     /// hash and nonce.
-    function settlementMessage(bytes calldata settlement, uint256 nonce) public view returns (bytes32) {
+    function settlementMessage(bytes calldata settlement, uint256 nonce) external view returns (bytes32) {
+        return settlementMessage(keccak256(settlement), nonce);
+    }
+
+    /// @dev Returns the EIP-712 signing digest for the specified settlement
+    /// hash and nonce.
+    function settlementMessage(bytes32 settlementDigest, uint256 nonce) private view returns (bytes32) {
         return keccak256(abi.encodePacked(
             hex"1901",
             domainSeparator,
             keccak256(abi.encode(
                 keccak256("Settlement(bytes settlement,uint256 nonce)"),
-                keccak256(settlement),
+                settlementDigest,
                 nonce
             ))
         ));


### PR DESCRIPTION
This PR makes a small gas optimization around the settlement call by avoiding an `EXTCODESIZE` and slightly more efficient calldata copying to memory for the `CALL`.

This is not as much as I had originally expected, but it makes sense since the additional `EXTCODESIZE` only adds 100 additional gas (because the slot will be warm). Still worth it IMO - as 300 gas can add up quickly over 1000s of calls, and the assembly code doesn't do anything exotic.

### Test Plan

Unit tests still pass and:

```
% npm run -s bench # Before:
gas used: 42071

% npm run -s bench # After:
gas used: 41802
```