### PR TITLE
Implement Nonce Cancellation

### DIFF
--- a/contracts/SolverTrampoline.sol
+++ b/contracts/SolverTrampoline.sol
@@ -79,6 +79,11 @@ contract SolverTrampoline {
         emit TrampolinedSettlement(solver, nonce);
     }
 
+    /// @dev Cancels the current nonce for the caller, returning its value.
+    function cancelCurrentNonce() external returns (uint256) {
+        return nonces[msg.sender]++;
+    }
+
     /// @dev Returns the EIP-712 signing digest for the specified settlement
     /// hash, nonce, and block deadline.
     function settlementMessage(bytes calldata settlement, uint256 nonce, uint256 deadline) public view returns (bytes32) {

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -41,8 +41,8 @@ async function main() {
 
   // Ensure that the solver already has executed a trampolined settlement in
   // order for its nonce to be non-zero.
-  const firstSettlement = await trampolineEmptyTestSettlement();
-  await firstSettlement.wait();
+  const cancelFirstNonce = await solverTrampoline.cancelCurrentNonce();
+  await cancelFirstNonce.wait();
 
   const trampolinedSettlement = await trampolineEmptyTestSettlement();
   const { gasUsed: trampolineGasUsed } = await trampolinedSettlement.wait();


### PR DESCRIPTION
Partial fulfillment of #10

This PR adds a new contract function for cancelling the current nonce. This is provided as a convenience for solvers to cancel any in-flight settlement transactions they may have.

### Test

Added new unit test, we still have full coverage in the trampoline contract.
```
-----------------------|----------|----------|----------|----------|----------------|
File                   |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-----------------------|----------|----------|----------|----------|----------------|
 contracts/            |      100 |      100 |      100 |      100 |                |
  CoWProtocol.sol      |      100 |      100 |      100 |      100 |                |
  SolverTrampoline.sol |      100 |      100 |      100 |      100 |                |
 contracts/test/       |      100 |      100 |      100 |      100 |                |
  CoWProtocol.sol      |      100 |      100 |      100 |      100 |                |
-----------------------|----------|----------|----------|----------|----------------|
All files              |      100 |      100 |      100 |      100 |                |
-----------------------|----------|----------|----------|----------|----------------|
```