### PR TITLE
Add Settlement Fallback Test

### DIFF
--- a/test/SolverTrampoline.ts
+++ b/test/SolverTrampoline.ts
@@ -105,6 +105,28 @@ describe("SolverTrampoline", function () {
         .to.equal(nonce.add(1));
     });
 
+    it("Allows executing any settlement contract function", async function () {
+      const {
+        solverTrampoline,
+        domain,
+        solver,
+      } = await loadFixture(fixture);
+
+      // Try an execute any function, like the fallback function.
+      const fallback = "0x";
+
+      const nonce = await solverTrampoline.nonces(solver.address);
+      const signature = await solver._signTypedData(
+        domain,
+        EIP712_TYPES,
+        { settlement: fallback, nonce },
+      );
+
+      const { r, s, v } = ethers.utils.splitSignature(signature);
+      await expect(solverTrampoline.settle(fallback, nonce, r, s, v))
+        .to.not.be.reverted;
+    });
+
     it("Should propagate settlement reverts", async function () {
       const { solverTrampoline, signTestSettlement, solver } =
         await loadFixture(fixture);


### PR DESCRIPTION
During the Smart Contract call, @fedgiac was surprised that we allowed the trampoline contract to call the Settlement contract fallback function.

This PR just adds a unit test that does this - mostly for documentation purposes that this is possible and allowed with the trampoline contract.