### PR TITLE
Add Settlement Deadline

### DIFF
--- a/contracts/SolverTrampoline.sol
+++ b/contracts/SolverTrampoline.sol
@@ -30,7 +30,7 @@ contract SolverTrampoline {
     /// recovered signer.
     error InvalidNonce();
     /// @dev Error indicating that the block deadline has past.
-    error Expired();
+    error Expired(uint256 deadline, uint256 block);
 
     constructor(Settlement settlementContract_) {
         settlementContract = settlementContract_;
@@ -56,8 +56,8 @@ contract SolverTrampoline {
         }
         nonces[solver] = nonce + 1;
 
-        if (block.number > deadline) {
-            revert Expired();
+        if (deadline < block.number) {
+            revert Expired(deadline, block.number);
         }
 
         // Use a low-level `call` instead of calling `settle` directly. This is

--- a/contracts/SolverTrampoline.sol
+++ b/contracts/SolverTrampoline.sol
@@ -26,8 +26,11 @@ contract SolverTrampoline {
     /// @dev Error indicating that the signer of a settlement is not an
     /// authorized solver.
     error Unauthorized(address solver);
-    /// @dev Error that the specified nonce is not valid for the signer.
+    /// @dev Error indicating that the specified nonce is not valid for the
+    /// recovered signer.
     error InvalidNonce();
+    /// @dev Error indicating that the block deadline has past.
+    error Expired();
 
     constructor(Settlement settlementContract_) {
         settlementContract = settlementContract_;
@@ -41,8 +44,8 @@ contract SolverTrampoline {
     }
 
     /// @dev Executes a settlement on behalf of a solver.
-    function settle(bytes calldata settlement, uint256 nonce, bytes32 r, bytes32 s, uint8 v) external {
-        bytes32 messageDigest = settlementMessage(settlement, nonce);
+    function settle(bytes calldata settlement, uint256 nonce, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external {
+        bytes32 messageDigest = settlementMessage(settlement, nonce, deadline);
         address solver = ecrecover(messageDigest, v, r, s);
         if (solver == address(0) || !solverAuthenticator.isSolver(solver)) {
             revert Unauthorized(solver);
@@ -52,6 +55,10 @@ contract SolverTrampoline {
             revert InvalidNonce();
         }
         nonces[solver] = nonce + 1;
+
+        if (block.number > deadline) {
+            revert Expired();
+        }
 
         // Use a low-level `call` instead of calling `settle` directly. This is
         // for a couple reasons:
@@ -73,15 +80,16 @@ contract SolverTrampoline {
     }
 
     /// @dev Returns the EIP-712 signing digest for the specified settlement
-    /// hash and nonce.
-    function settlementMessage(bytes calldata settlement, uint256 nonce) public view returns (bytes32) {
+    /// hash, nonce, and block deadline.
+    function settlementMessage(bytes calldata settlement, uint256 nonce, uint256 deadline) public view returns (bytes32) {
         return keccak256(abi.encodePacked(
             hex"1901",
             domainSeparator,
             keccak256(abi.encode(
-                keccak256("Settlement(bytes settlement,uint256 nonce)"),
+                keccak256("Settlement(bytes settlement,uint256 nonce,uint256 deadline)"),
                 keccak256(settlement),
-                nonce
+                nonce,
+                deadline
             ))
         ));
     }

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -15,6 +15,7 @@ async function main() {
   async function trampolineEmptyTestSettlement() {
     const emptySettlement = "0x";
     const nonce = await solverTrampoline.nonces(solver.address);
+    const deadline = ethers.constants.MaxUint256;
     const signature = await solver._signTypedData(
       {
         chainId,
@@ -24,16 +25,18 @@ async function main() {
         Settlement: [
           { name: "settlement", type: "bytes" },
           { name: "nonce", type: "uint256" },
+          { name: "deadline", type: "uint256" },
         ],
       },
       {
         settlement: emptySettlement,
         nonce,
+        deadline,
       },
     );
 
-    const { r, s, v } = await ethers.utils.splitSignature(signature);
-    return await solverTrampoline.settle(emptySettlement, nonce, r, s, v);
+    const { v, r, s } = await ethers.utils.splitSignature(signature);
+    return await solverTrampoline.settle(emptySettlement, nonce, deadline, v, r, s);
   }
 
   // Ensure that the solver already has executed a trampolined settlement in

--- a/test/SolverTrampoline.ts
+++ b/test/SolverTrampoline.ts
@@ -76,8 +76,11 @@ describe("SolverTrampoline", function () {
     });
 
     it("Should set CoW Protocol contract addresses", async function () {
-      const { settlementContract, solverAuthenticator, solverTrampoline } =
-        await loadFixture(fixture);
+      const {
+        settlementContract,
+        solverAuthenticator,
+        solverTrampoline,
+      } = await loadFixture(fixture);
 
       expect(await solverTrampoline.settlementContract())
         .to.equal(settlementContract.address);
@@ -88,8 +91,7 @@ describe("SolverTrampoline", function () {
 
   describe("settle", function () {
     it("Should execute a settlement and increment nonce", async function () {
-      const { solverTrampoline, signTestSettlement, solver } =
-        await loadFixture(fixture);
+      const { solverTrampoline, signTestSettlement, solver } = await loadFixture(fixture);
 
       const nonce = await solverTrampoline.nonces(solver.address);
       const deadline = await ethers.provider.getBlockNumber() + 1;
@@ -108,30 +110,26 @@ describe("SolverTrampoline", function () {
     });
 
     it("Allows executing any settlement contract function", async function () {
-      const {
-        solverTrampoline,
-        domain,
-        solver,
-      } = await loadFixture(fixture);
+      const { solverTrampoline, domain, solver } = await loadFixture(fixture);
 
       // Try an execute any function, like the fallback function.
       const fallback = "0x";
 
       const nonce = await solverTrampoline.nonces(solver.address);
+      const deadline = ethers.constants.MaxUint256;
       const signature = await solver._signTypedData(
         domain,
         EIP712_TYPES,
-        { settlement: fallback, nonce },
+        { settlement: fallback, nonce, deadline },
       );
 
       const { r, s, v } = ethers.utils.splitSignature(signature);
-      await expect(solverTrampoline.settle(fallback, nonce, r, s, v))
+      await expect(solverTrampoline.settle(fallback, nonce, deadline, v, r, s))
         .to.not.be.reverted;
     });
 
     it("Should propagate settlement reverts", async function () {
-      const { solverTrampoline, signTestSettlement, solver } =
-        await loadFixture(fixture);
+      const { solverTrampoline, signTestSettlement, solver } = await loadFixture(fixture);
 
       const nonce = await solverTrampoline.nonces(solver.address);
       const deadline = ethers.constants.MaxUint256;
@@ -158,8 +156,7 @@ describe("SolverTrampoline", function () {
     });
 
     it("Should deny settlements signed unauthorized solvers", async function () {
-      const { solverTrampoline, signTestSettlement, notSolver } =
-        await loadFixture(fixture);
+      const { solverTrampoline, signTestSettlement, notSolver } = await loadFixture(fixture);
 
       const nonce = await solverTrampoline.nonces(notSolver.address);
       const deadline = ethers.constants.MaxUint256;
@@ -176,8 +173,7 @@ describe("SolverTrampoline", function () {
     });
 
     it("Should deny settlements with incorrect nonces", async function () {
-      const { solverTrampoline, signTestSettlement, solver } =
-        await loadFixture(fixture);
+      const { solverTrampoline, signTestSettlement, solver } = await loadFixture(fixture);
 
       const nonce = await solverTrampoline.nonces(solver.address);
       const wrongNonce = nonce.add(1);
@@ -194,11 +190,7 @@ describe("SolverTrampoline", function () {
     });
 
     it("Should deny expired settlements", async function () {
-      const {
-        solverTrampoline,
-        signTestSettlement,
-        solver,
-      } = await loadFixture(fixture);
+      const { solverTrampoline, signTestSettlement, solver } = await loadFixture(fixture);
 
       const nonce = await solverTrampoline.nonces(solver.address);
       const deadline = await ethers.provider.getBlockNumber();
@@ -210,7 +202,8 @@ describe("SolverTrampoline", function () {
       } = await signTestSettlement(solver, nonce, deadline);
 
       await expect(solverTrampoline.settle(settlement, nonce, deadline, v, r, s))
-        .to.be.revertedWithCustomError(solverTrampoline, "Expired");
+        .to.be.revertedWithCustomError(solverTrampoline, "Expired")
+        .withArgs(deadline, deadline + 1);
     });
   });
 


### PR DESCRIPTION
With #11, closes #10.

This PR adds a signed **block** deadline parameter to the settlement trampoline contract. The motivation behind this change is to make it easier for solvers to manage in-flight trampolined settlements: if a solver sees a certain block height and their settlement has not yet been mined, they know that they don't need to execute a `cancelCurrentNonce` transaction, and can reuse the previous nonce (as the signed settlement is no longer valid). Additionally, this fits nicely into the protocol as we want solvers to "time out" execution at some point anyway (we currently implement this by sending "cancellation transactions" from EOA solvers).

Note that I decided to use a block deadline instead of a time based one. The idea here is that we want to transistion the protocol to be more block-centric, and I think this is a step in the right direction. Furthermore, for PoS, block number and block timestamp are largely equivalent for deadlines anyway.

### Test Plan

Added unit test.