### PR TITLE
Add Additional Invalid Nonce Error Context

### DIFF
--- a/.github/workflows/hardhat.yml
+++ b/.github/workflows/hardhat.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: hardhat
     runs-on: ubuntu-latest
 
     steps:

--- a/contracts/SolverTrampoline.sol
+++ b/contracts/SolverTrampoline.sol
@@ -28,7 +28,7 @@ contract SolverTrampoline {
     error Unauthorized(address solver);
     /// @dev Error indicating that the specified nonce is not valid for the
     /// recovered signer.
-    error InvalidNonce();
+    error InvalidNonce(uint256 nonce, uint256 current);
     /// @dev Error indicating that the block deadline has past.
     error Expired(uint256 deadline, uint256 block);
 
@@ -51,8 +51,9 @@ contract SolverTrampoline {
             revert Unauthorized(solver);
         }
 
-        if (nonce != nonces[solver]) {
-            revert InvalidNonce();
+        uint256 currentNonce = nonces[solver];
+        if (nonce != currentNonce) {
+            revert InvalidNonce(nonce, currentNonce);
         }
         nonces[solver] = nonce + 1;
 

--- a/test/SolverTrampoline.ts
+++ b/test/SolverTrampoline.ts
@@ -184,7 +184,8 @@ describe("SolverTrampoline", function () {
       } = await signTestSettlement(solver, wrongNonce, deadline);
 
       await expect(solverTrampoline.settle(settlement, wrongNonce, deadline, v, r, s))
-        .to.be.revertedWithCustomError(solverTrampoline, "InvalidNonce");
+        .to.be.revertedWithCustomError(solverTrampoline, "InvalidNonce")
+        .withArgs(wrongNonce, nonce);
     });
 
     it("Should deny expired settlements", async function () {


### PR DESCRIPTION
This PR adds additional error context to the `InvalidNonce` error so that it includes the specified nonce and the actual current nonce.

The motivation behind this change is to make debugging reverts easier. Note that this adds a meaningless 5 additional gas to the happy path, and so is very low cost for additional debuggability.

### Test Plan

Existing test now checks for error data.